### PR TITLE
fix(Tizen): Work around misreported AC-3 support on Tizen

### DIFF
--- a/lib/media/drm_engine.js
+++ b/lib/media/drm_engine.js
@@ -659,9 +659,22 @@ shaka.media.DrmEngine.prototype.willSupport = function(contentType) {
   // first MIME type even if the others are supported.  To work around this,
   // we say that Edge supports everything.
   //
-  // See: https://bit.ly/2IcEgv0 and Issue #1495
+  // See https://github.com/google/shaka-player/issues/1495 for details.
   if (shaka.util.Platform.isEdge()) {
     return true;
+  }
+
+  contentType = contentType.toLowerCase();
+
+  if (shaka.util.Platform.isTizen() &&
+      contentType.includes('codecs="ac-3"')) {
+    // Some Tizen devices seem to misreport AC-3 support.  This works around
+    // the issue, by falling back to EC-3, which seems to be supported on the
+    // same devices and be correctly reported in all cases we have observed.
+    // See https://github.com/google/shaka-player/issues/2989 for details.
+    const fallback = contentType.replace('ac-3', 'ec-3');
+    return this.supportedTypes_.has(contentType) ||
+           this.supportedTypes_.has(fallback);
   }
 
   return this.supportedTypes_.has(contentType);
@@ -802,6 +815,17 @@ shaka.media.DrmEngine.prototype.prepareMediaKeyConfigsForVariants_ = function(
         shaka.util.MimeUtils.getFullType(video.mimeType, video.codecs) :
         '';
 
+    let fallbackAudioMimeType = null;
+    if (audio &&
+        audio.codecs.toLowerCase() == 'ac-3' &&
+        shaka.util.Platform.isTizen()) {
+      // Some Tizen devices seem to misreport AC-3 support, but correctly
+      // report EC-3 support.  So query EC-3 as a fallback for AC-3.
+      // See https://github.com/google/shaka-player/issues/2989 for details.
+      fallbackAudioMimeType = shaka.util.MimeUtils.getFullType(
+          audio.mimeType, 'ec-3');
+    }
+
     // Add the last bit of information to each config;
     for (const info of variant.drmInfos) {
       const config = configs.get(info.keySystem);
@@ -837,6 +861,18 @@ shaka.media.DrmEngine.prototype.prepareMediaKeyConfigsForVariants_ = function(
         };
 
         config.videoCapabilities.push(capability);
+      }
+
+      // This is how we work around some misbehaving platforms by adding
+      // synthetic capability records using a fallback MIME type.
+      if (audio && fallbackAudioMimeType) {
+        /** @type {MediaKeySystemMediaCapability} */
+        const fallbackCapability = {
+          robustness: info.audioRobustness || '',
+          contentType: fallbackAudioMimeType,
+        };
+
+        config.audioCapabilities.push(fallbackCapability);
       }
     }
   }


### PR DESCRIPTION
Some Tizen devices seem to misreport AC-3 support.  This works around
the issue by falling back to EC-3, which seems to be supported on the
same devices and be correctly reported in all cases we have observed.

Closes #2989

Change-Id: I80f20ba796df29858728b19f8a9f6c1712c9556d