### PR TITLE
Revert "IMPR: Do not use drift when looking segments."

### DIFF
--- a/lib/media/streaming_engine.js
+++ b/lib/media/streaming_engine.js
@@ -1580,8 +1580,20 @@ shaka.media.StreamingEngine.prototype.getSegmentReferenceNeeded_ = function(
     return null;
   }
 
-  return this.getSegmentReferenceIfAvailable_(
-      mediaState, currentPeriodIndex, position);
+  let reference = null;
+  if (bufferEnd == null) {
+    // If there's positive drift then we need to get the previous segment;
+    // however, we don't actually know how much drift there is, so we must
+    // unconditionally get the previous segment. If it turns out that there's
+    // non-positive drift then we'll just end up buffering beind the playhead a
+    // little more than we needed.
+    let optimalPosition = Math.max(0, position - 1);
+    reference = this.getSegmentReferenceIfAvailable_(
+        mediaState, currentPeriodIndex, optimalPosition);
+  }
+  return reference ||
+      this.getSegmentReferenceIfAvailable_(
+          mediaState, currentPeriodIndex, position);
 };
 
 


### PR DESCRIPTION
Reverts sokolovstas/shaka-player#3

В итоге тестировщики обнаружили баг, поэтому откатываю. Позже попробую доработать, но уже отдельным патчем. 